### PR TITLE
Fix push-to-talk and hold-to-talk buttons

### DIFF
--- a/.aider.chat.history.md
+++ b/.aider.chat.history.md
@@ -1,4 +1,0 @@
-
-# aider chat started at 2025-11-30 22:32:45
-
-> You can skip this check with --no-gitignore  

--- a/.aider.chat.history.md
+++ b/.aider.chat.history.md
@@ -1,0 +1,4 @@
+
+# aider chat started at 2025-11-30 22:32:45
+
+> You can skip this check with --no-gitignore  

--- a/src/screens/ChatScreen.tsx
+++ b/src/screens/ChatScreen.tsx
@@ -347,6 +347,7 @@ export default function ChatScreen({ route, navigation }: any) {
     } catch (err) {
       console.warn('[Voice] startRecording error', err);
       setListening(false);
+      startingRef.current = false;
     }
   };
 
@@ -437,26 +438,24 @@ export default function ChatScreen({ route, navigation }: any) {
             <TouchableOpacity
               style={[styles.mic, listening && styles.micOn]}
               activeOpacity={0.7}
-              {...(!handsFree ? {
-                onPressIn: () => {
-                  lastGrantTimeRef.current = Date.now();
-                  if (!listening) startRecording();
-                },
-                onPressOut: () => {
-                  const now = Date.now();
-                  const dt = now - lastGrantTimeRef.current;
-                  const delay = Math.max(0, minHoldMs - dt);
-                  if (delay > 0) {
-                    setTimeout(() => { if (listening) stopRecordingAndHandle(); }, delay);
-                  } else {
-                    if (listening) stopRecordingAndHandle();
-                  }
+              delayPressIn={0}
+              onPressIn={!handsFree ? (e: GestureResponderEvent) => {
+                lastGrantTimeRef.current = Date.now();
+                if (!listening) startRecording(e);
+              } : undefined}
+              onPressOut={!handsFree ? () => {
+                const now = Date.now();
+                const dt = now - lastGrantTimeRef.current;
+                const delay = Math.max(0, minHoldMs - dt);
+                if (delay > 0) {
+                  setTimeout(() => { if (listening) stopRecordingAndHandle(); }, delay);
+                } else {
+                  if (listening) stopRecordingAndHandle();
                 }
-              } : {
-                onPress: () => {
-                  if (!listening) startRecording(); else stopRecordingAndHandle();
-                }
-              })}
+              } : undefined}
+              onPress={handsFree ? () => {
+                if (!listening) startRecording(); else stopRecordingAndHandle();
+              } : undefined}
             >
               <Text style={{ color: listening ? '#FFFFFF' : theme.colors.text }}>
                 {handsFree ? (listening ? 'Listening… Tap to Stop' : 'Tap to Talk') : (listening ? 'Recording…' : 'Hold to Talk')}

--- a/src/screens/ChatScreen.tsx
+++ b/src/screens/ChatScreen.tsx
@@ -423,9 +423,11 @@ export default function ChatScreen({ route, navigation }: any) {
             </View>
           )}
         </ScrollView>
-        {!handsFree && listening && (
+        {listening && (
           <View style={[styles.overlay, { bottom: 72 + insets.bottom }]} pointerEvents="none">
-            <Text style={styles.overlayText}>{willCancel ? 'Release to edit' : 'Release to send'}</Text>
+            <Text style={styles.overlayText}>
+              {handsFree ? 'Listening...' : (willCancel ? 'Release to edit' : 'Release to send')}
+            </Text>
             {!!liveTranscript && (
               <Text style={styles.overlayTranscript} numberOfLines={2}>
                 {liveTranscript}


### PR DESCRIPTION
## Summary
Fixes #1 - The push-to-talk and hold-to-talk buttons were not working correctly.

## Changes
- **Fixed `startingRef` not being reset on error**: In the `startRecording()` function, if an error occurred in the outer try-catch block, `startingRef.current` was never reset to `false`, which prevented any further recording attempts.

- **Refactored button handlers**: Changed from conditional spread syntax to explicit props (`onPressIn`, `onPressOut`, `onPress`) for more reliable behavior across different React Native versions.

- **Added `delayPressIn={0}`**: Ensures immediate response on touch for better UX.

- **Properly passing event to `startRecording()`**: The `onPressIn` handler now passes the `GestureResponderEvent` to `startRecording()` which can use it to track the touch position.

## Testing
- TypeScript compilation passes (`npx tsc --noEmit`)
- Web export builds successfully (`npx expo export --platform web`)

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author