### PR TITLE
feat: add kill switch button with confirmation dialog

### DIFF
--- a/src/lib/openaiClient.ts
+++ b/src/lib/openaiClient.ts
@@ -230,5 +230,47 @@ export class OpenAIClient {
       throw error;
     }
   }
+
+  /**
+   * POST /v1/emergency-stop - Kill switch to stop all agent sessions on the remote server
+   * Returns success status and number of processes killed
+   */
+  async killSwitch(): Promise<{ success: boolean; message?: string; error?: string; processesKilled?: number }> {
+    const url = this.getUrl('/emergency-stop');
+    console.log('[OpenAIClient] Triggering emergency stop:', url);
+
+    try {
+      const res = await fetch(url, {
+        method: 'POST',
+        headers: this.authHeaders(),
+        body: JSON.stringify({}), // Fastify requires a body when Content-Type is application/json
+      });
+
+      console.log('[OpenAIClient] Kill switch response:', res.status, res.statusText);
+
+      const data = await res.json().catch(() => ({}));
+
+      if (!res.ok) {
+        console.error('[OpenAIClient] Kill switch error:', data);
+        return {
+          success: false,
+          error: data?.error || `Kill switch failed: ${res.status}`,
+        };
+      }
+
+      console.log('[OpenAIClient] Kill switch success:', data);
+      return {
+        success: true,
+        message: data?.message || 'Emergency stop executed',
+        processesKilled: data?.processesKilled,
+      };
+    } catch (error: any) {
+      console.error('[OpenAIClient] Kill switch request failed:', error);
+      return {
+        success: false,
+        error: error?.message || 'Failed to connect to server',
+      };
+    }
+  }
 }
 


### PR DESCRIPTION
## Summary
Adds a kill switch button to the mobile app that allows users to remotely trigger an emergency stop on the connected SpeakMCP server.

## Changes

### OpenAIClient (`src/lib/openaiClient.ts`)
- Add `killSwitch()` method that calls `POST /v1/emergency-stop`
- Returns success status with process count information

### ChatScreen (`src/screens/ChatScreen.tsx`)
- Add red circular kill switch button (⏹) in header next to hands-free toggle
- Show confirmation dialog before triggering (prevents accidental activation)
- Support both web (`window.confirm`) and native (`Alert.alert`) platforms
- Display success/error feedback after execution

## UI
The kill switch appears as a red circular button with a stop icon in the navigation header. When tapped:
1. Shows confirmation dialog: "Are you sure you want to stop all agent sessions?"
2. On confirmation, calls the remote server's emergency stop endpoint
3. Shows success/error alert with result

## Related
Requires the `/v1/emergency-stop` endpoint from SpeakMCP (see https://github.com/aj47/SpeakMCP/pull/398)

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author