### PR TITLE
fix: Conversation continuity and back button navigation

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -3,8 +3,10 @@ import { NavigationContainer, DefaultTheme } from '@react-navigation/native';
 import { createNativeStackNavigator } from '@react-navigation/native-stack';
 import SettingsScreen from './src/screens/SettingsScreen';
 import ChatScreen from './src/screens/ChatScreen';
+import SessionListScreen from './src/screens/SessionListScreen';
 import { ConfigContext, useConfig, saveConfig } from './src/store/config';
-import { View, ActivityIndicator, Image } from 'react-native';
+import { SessionContext, useSessionStore } from './src/store/sessions';
+import { View, ActivityIndicator, Image, TouchableOpacity, Text } from 'react-native';
 import { SafeAreaProvider } from 'react-native-safe-area-context';
 import { theme } from './src/ui/theme';
 import * as Linking from 'expo-linking';
@@ -39,6 +41,7 @@ function parseDeepLink(url: string | null) {
 
 function Root() {
   const cfg = useConfig();
+  const sessionStore = useSessionStore();
 
   // Handle deep links
   useEffect(() => {
@@ -68,7 +71,7 @@ function Root() {
     return () => subscription.remove();
   }, [cfg.ready]);
 
-  if (!cfg.ready) {
+  if (!cfg.ready || sessionStore.isLoading) {
     return (
       <View style={{ flex: 1, alignItems: 'center', justifyContent: 'center' }}>
         <ActivityIndicator />
@@ -77,24 +80,41 @@ function Root() {
   }
   return (
     <ConfigContext.Provider value={cfg}>
-      <NavigationContainer theme={navTheme}>
-        <Stack.Navigator
-          screenOptions={{
-            headerTitleStyle: { ...theme.typography.h2 },
-            contentStyle: { backgroundColor: theme.colors.background },
-            headerLeft: () => (
-              <Image
-                source={require('./assets/favicon.png')}
-                style={{ width: 28, height: 28, marginLeft: 12, marginRight: 8 }}
-                resizeMode="contain"
-              />
-            ),
-          }}
-        >
-          <Stack.Screen name="Settings" component={SettingsScreen} />
-          <Stack.Screen name="Chat" component={ChatScreen} />
-        </Stack.Navigator>
-      </NavigationContainer>
+      <SessionContext.Provider value={sessionStore}>
+        <NavigationContainer theme={navTheme}>
+          <Stack.Navigator
+            screenOptions={{
+              headerTitleStyle: { ...theme.typography.h2 },
+              contentStyle: { backgroundColor: theme.colors.background },
+            }}
+          >
+            <Stack.Screen
+              name="Sessions"
+              component={SessionListScreen}
+              options={{
+                title: 'Chats',
+                headerLeft: () => (
+                  <Image
+                    source={require('./assets/favicon.png')}
+                    style={{ width: 28, height: 28, marginLeft: 12, marginRight: 8 }}
+                    resizeMode="contain"
+                  />
+                ),
+              }}
+            />
+            <Stack.Screen
+              name="Settings"
+              component={SettingsScreen}
+              options={{ headerBackTitle: 'Back' }}
+            />
+            <Stack.Screen
+              name="Chat"
+              component={ChatScreen}
+              options={{ headerBackTitle: 'Chats' }}
+            />
+          </Stack.Navigator>
+        </NavigationContainer>
+      </SessionContext.Provider>
     </ConfigContext.Provider>
   );
 }

--- a/src/lib/openaiClient.ts
+++ b/src/lib/openaiClient.ts
@@ -10,6 +10,11 @@ export type ChatMessage = {
   content?: string;
 };
 
+export interface ChatResponse {
+  content: string;
+  conversationId?: string;
+}
+
 
 
 export class OpenAIClient {
@@ -59,32 +64,37 @@ export class OpenAIClient {
    * POST OpenAI-compatible API: /v1/chat/completions
    * If the server responds with text/event-stream, this will parse SSE chunks and accumulate assistant content.
    * You can pass an onToken callback to receive incremental tokens.
+   *
+   * @param messages - Array of chat messages
+   * @param onToken - Optional callback for streaming tokens
+   * @param conversationId - Optional conversation ID for continuing existing conversations
+   * @returns ChatResponse with content and optional conversationId
    */
   async chat(
     messages: ChatMessage[],
-    onToken?: (token: string) => void
-  ): Promise<string> {
+    onToken?: (token: string) => void,
+    conversationId?: string
+  ): Promise<ChatResponse> {
     const url = this.getUrl('/chat/completions');
-    const body = { model: this.cfg.model, messages, stream: true } as any;
+    const body = {
+      model: this.cfg.model,
+      messages,
+      stream: true,
+      ...(conversationId && { conversation_id: conversationId }), // Send conversation_id if provided
+    } as any;
 
     console.log('[OpenAIClient] Starting chat request');
     console.log('[OpenAIClient] URL:', url);
     console.log('[OpenAIClient] Model:', this.cfg.model);
     console.log('[OpenAIClient] Messages count:', messages.length);
-    console.log('[OpenAIClient] Headers:', JSON.stringify(this.authHeaders(), null, 2));
-    console.log('[OpenAIClient] Request body:', JSON.stringify(body, null, 2));
+    console.log('[OpenAIClient] Conversation ID:', conversationId || 'none (new conversation)');
+    console.log('[OpenAIClient] Messages being sent:');
+    messages.forEach((msg, i) => {
+      console.log(`[OpenAIClient]   [${i}] ${msg.role}: "${(msg.content || '').substring(0, 60)}..."`);
+    });
 
-    // Test basic connectivity first
-    console.log('[OpenAIClient] Testing basic connectivity...');
-    try {
-      const testResponse = await fetch(url.replace('/chat/completions', '/models'), {
-        method: 'GET',
-        headers: this.authHeaders(),
-      });
-      console.log('[OpenAIClient] Connectivity test result:', testResponse.status, testResponse.statusText);
-    } catch (connectError) {
-      console.error('[OpenAIClient] Connectivity test failed:', connectError);
-    }
+    // Track conversation_id from response
+    let responseConversationId: string | undefined = conversationId;
 
     try {
       const res = await fetch(url, {
@@ -94,7 +104,6 @@ export class OpenAIClient {
       });
 
       console.log('[OpenAIClient] Response status:', res.status, res.statusText);
-      console.log('[OpenAIClient] Response headers:', Object.fromEntries(res.headers.entries()));
 
       if (!res.ok) {
         const text = await res.text().catch(() => '');
@@ -103,27 +112,30 @@ export class OpenAIClient {
       }
 
       const ct = res.headers.get('content-type') || '';
-      console.log('[OpenAIClient] Content-Type:', ct);
-
       const isSSE = ct.includes('text/event-stream');
       const supportsReader = !!(res as any)?.body && typeof (res as any).body.getReader === 'function';
 
-      console.log('[OpenAIClient] Is SSE:', isSSE);
-      console.log('[OpenAIClient] Supports Reader:', supportsReader);
+      console.log('[OpenAIClient] Is SSE:', isSSE, 'Supports Reader:', supportsReader);
 
       // Non-SSE responses: parse JSON content or return raw text
       if (!isSSE) {
         console.log('[OpenAIClient] Processing non-SSE response');
         const text = await res.text();
-        console.log('[OpenAIClient] Response text:', text);
         try {
           const j = JSON.parse(text);
           const content = j?.choices?.[0]?.message?.content ?? '';
-          console.log('[OpenAIClient] Extracted content:', content);
-          return typeof content === 'string' ? content : text;
+          // Extract conversation_id from response if present
+          if (j?.conversation_id) {
+            responseConversationId = j.conversation_id;
+            console.log('[OpenAIClient] Received conversation_id:', responseConversationId);
+          }
+          return {
+            content: typeof content === 'string' ? content : text,
+            conversationId: responseConversationId,
+          };
         } catch (parseError) {
           console.error('[OpenAIClient] JSON parse error:', parseError);
-          return text;
+          return { content: text, conversationId: responseConversationId };
         }
       }
 
@@ -132,19 +144,20 @@ export class OpenAIClient {
         console.log('[OpenAIClient] Using SSE fallback (no reader support)');
         const text = await res.text();
         console.log('[OpenAIClient] Raw SSE text length:', text.length);
-        console.log('[OpenAIClient] Raw SSE text preview:', text.substring(0, 500));
         let finalText = '';
         const chunks = text.split(/\r?\n\r?\n/);
-        console.log('[OpenAIClient] Split into', chunks.length, 'chunks');
         for (const chunk of chunks) {
-        const lines = chunk.split(/\r?\n/).map(l => l.replace(/^data:\s?/, '').trim()).filter(Boolean);
+          const lines = chunk.split(/\r?\n/).map(l => l.replace(/^data:\s?/, '').trim()).filter(Boolean);
           for (const l of lines) {
             if (l === '[DONE]' || l === '"[DONE]"') {
-              console.log('[OpenAIClient] Found DONE marker, returning:', finalText.length, 'characters');
-              return finalText;
+              return { content: finalText, conversationId: responseConversationId };
             }
             try {
               const obj = JSON.parse(l);
+              // Check for conversation_id in any chunk
+              if (obj?.conversation_id) {
+                responseConversationId = obj.conversation_id;
+              }
               const delta = obj?.choices?.[0]?.delta;
               let token = delta?.content as string | undefined;
               if (!token && obj?.choices?.[0]?.message?.content) {
@@ -155,21 +168,19 @@ export class OpenAIClient {
                   try {
                     const inner = JSON.parse(token);
                     if (inner?.type === 'data-operation') {
-                      continue; // ignore control events embedded in content
+                      continue;
                     }
                   } catch {}
                 }
                 finalText += token;
-                console.log('[OpenAIClient] Token received:', token);
                 onToken?.(token);
               }
-            } catch (parseError) {
-              console.log('[OpenAIClient] Ignoring non-JSON line:', l);
+            } catch {
+              // Ignore non-JSON lines
             }
           }
         }
-        console.log('[OpenAIClient] SSE fallback complete, final text length:', finalText.length);
-        return finalText;
+        return { content: finalText, conversationId: responseConversationId };
       }
 
       // Streaming parse
@@ -180,51 +191,45 @@ export class OpenAIClient {
       let finalText = '';
       while (true) {
         const { value, done } = await reader.read();
-        if (done) {
-          console.log('[OpenAIClient] Stream ended, final text length:', finalText.length);
-          break;
-        }
+        if (done) break;
         buffer += decoder.decode(value, { stream: true });
         let idx;
         while ((idx = buffer.indexOf('\n\n')) !== -1) {
-        const chunk = buffer.slice(0, idx).trim();
-        buffer = buffer.slice(idx + 2);
-        if (!chunk) continue;
-        // Each SSE event line typically starts with "data: "
-        const lines = chunk.split('\n').map(l => l.replace(/^data:\s?/, ''));
-        for (const l of lines) {
-          if (!l) continue;
+          const chunk = buffer.slice(0, idx).trim();
+          buffer = buffer.slice(idx + 2);
+          if (!chunk) continue;
+          const lines = chunk.split('\n').map(l => l.replace(/^data:\s?/, ''));
+          for (const l of lines) {
+            if (!l) continue;
             if (l === '[DONE]' || l === '"[DONE]"') {
-              // End of stream
-              console.log('[OpenAIClient] Stream DONE, returning:', finalText.length, 'characters');
-              return finalText;
+              return { content: finalText, conversationId: responseConversationId };
             }
-          try {
-            const obj = JSON.parse(l);
-            const delta = obj?.choices?.[0]?.delta;
-            const token = delta?.content;
-            if (typeof token === 'string' && token.length > 0) {
-              // Some streams include JSON-encoded control messages in content; skip those
-              if (token.trim().startsWith('{')) {
-                try {
-                  const inner = JSON.parse(token);
-                  if (inner?.type === 'data-operation') {
-                    continue; // ignore control events
-                  }
-                } catch {}
+            try {
+              const obj = JSON.parse(l);
+              // Check for conversation_id
+              if (obj?.conversation_id) {
+                responseConversationId = obj.conversation_id;
               }
+              const delta = obj?.choices?.[0]?.delta;
+              const token = delta?.content;
+              if (typeof token === 'string' && token.length > 0) {
+                if (token.trim().startsWith('{')) {
+                  try {
+                    const inner = JSON.parse(token);
+                    if (inner?.type === 'data-operation') continue;
+                  } catch {}
+                }
                 finalText += token;
-                console.log('[OpenAIClient] Stream token received:', token);
                 onToken?.(token);
               }
-            } catch (parseError) {
-              console.log('[OpenAIClient] Ignoring non-JSON stream line:', l);
+            } catch {
+              // Ignore non-JSON lines
             }
+          }
         }
       }
-    }
 
-      return finalText;
+      return { content: finalText, conversationId: responseConversationId };
     } catch (error) {
       console.error('[OpenAIClient] Chat request failed:', error);
       throw error;

--- a/src/store/sessions.ts
+++ b/src/store/sessions.ts
@@ -1,0 +1,225 @@
+/**
+ * Session Store for Mobile App
+ * Manages multiple chat sessions with persistence via AsyncStorage
+ * Adapted from SpeakMCP/src/renderer/src/stores patterns
+ */
+
+import { createContext, useContext, useEffect, useState, useCallback } from 'react';
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import {
+  Session,
+  SessionListItem,
+  ChatMessage,
+  createSession,
+  generateMessageId,
+  sessionToListItem,
+} from '../types/session';
+
+const SESSIONS_STORAGE_KEY = 'speakmcp_sessions_v1';
+const CURRENT_SESSION_KEY = 'speakmcp_current_session_v1';
+
+export interface SessionStore {
+  sessions: Session[];
+  currentSessionId: string | null;
+  isLoading: boolean;
+
+  // Actions
+  loadSessions: () => Promise<void>;
+  createNewSession: (firstMessage?: string) => Session;
+  setCurrentSession: (sessionId: string | null) => void;
+  getCurrentSession: () => Session | null;
+  addMessageToSession: (sessionId: string, role: 'user' | 'assistant', content: string) => void;
+  updateSessionMessages: (sessionId: string, messages: ChatMessage[]) => void;
+  setServerConversationId: (sessionId: string, serverConversationId: string) => void;
+  deleteSession: (sessionId: string) => void;
+  clearAllSessions: () => void;
+  getSessionList: () => SessionListItem[];
+}
+
+/**
+ * Load sessions from AsyncStorage
+ */
+async function loadSessionsFromStorage(): Promise<Session[]> {
+  try {
+    const raw = await AsyncStorage.getItem(SESSIONS_STORAGE_KEY);
+    if (!raw) return [];
+    const parsed = JSON.parse(raw);
+    return Array.isArray(parsed) ? parsed : [];
+  } catch (error) {
+    console.error('[SessionStore] Failed to load sessions:', error);
+    return [];
+  }
+}
+
+/**
+ * Save sessions to AsyncStorage
+ */
+async function saveSessionsToStorage(sessions: Session[]): Promise<void> {
+  try {
+    await AsyncStorage.setItem(SESSIONS_STORAGE_KEY, JSON.stringify(sessions));
+  } catch (error) {
+    console.error('[SessionStore] Failed to save sessions:', error);
+  }
+}
+
+/**
+ * Load current session ID from AsyncStorage
+ */
+async function loadCurrentSessionId(): Promise<string | null> {
+  try {
+    return await AsyncStorage.getItem(CURRENT_SESSION_KEY);
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Save current session ID to AsyncStorage
+ */
+async function saveCurrentSessionId(sessionId: string | null): Promise<void> {
+  try {
+    if (sessionId) {
+      await AsyncStorage.setItem(CURRENT_SESSION_KEY, sessionId);
+    } else {
+      await AsyncStorage.removeItem(CURRENT_SESSION_KEY);
+    }
+  } catch (error) {
+    console.error('[SessionStore] Failed to save current session ID:', error);
+  }
+}
+
+/**
+ * Hook to create and manage the session store
+ */
+export function useSessionStore(): SessionStore {
+  const [sessions, setSessions] = useState<Session[]>([]);
+  const [currentSessionId, setCurrentSessionIdState] = useState<string | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+
+  // Load sessions on mount
+  const loadSessions = useCallback(async () => {
+    setIsLoading(true);
+    const [loadedSessions, savedCurrentId] = await Promise.all([
+      loadSessionsFromStorage(),
+      loadCurrentSessionId(),
+    ]);
+    setSessions(loadedSessions);
+    // Only set current session if it exists in loaded sessions
+    if (savedCurrentId && loadedSessions.some(s => s.id === savedCurrentId)) {
+      setCurrentSessionIdState(savedCurrentId);
+    }
+    setIsLoading(false);
+  }, []);
+
+  useEffect(() => {
+    loadSessions();
+  }, [loadSessions]);
+
+  // Persist sessions whenever they change
+  useEffect(() => {
+    if (!isLoading) {
+      saveSessionsToStorage(sessions);
+    }
+  }, [sessions, isLoading]);
+
+  const setCurrentSession = useCallback((sessionId: string | null) => {
+    setCurrentSessionIdState(sessionId);
+    saveCurrentSessionId(sessionId);
+  }, []);
+
+  const createNewSession = useCallback((firstMessage?: string): Session => {
+    const newSession = createSession(firstMessage);
+    setSessions(prev => [newSession, ...prev]);
+    setCurrentSession(newSession.id);
+    return newSession;
+  }, [setCurrentSession]);
+
+  const getCurrentSession = useCallback((): Session | null => {
+    if (!currentSessionId) return null;
+    return sessions.find(s => s.id === currentSessionId) || null;
+  }, [currentSessionId, sessions]);
+
+  const addMessageToSession = useCallback((
+    sessionId: string,
+    role: 'user' | 'assistant',
+    content: string
+  ) => {
+    setSessions(prev => prev.map(session => {
+      if (session.id !== sessionId) return session;
+      const newMessage: ChatMessage = {
+        id: generateMessageId(),
+        role,
+        content,
+        timestamp: Date.now(),
+      };
+      return {
+        ...session,
+        updatedAt: Date.now(),
+        messages: [...session.messages, newMessage],
+      };
+    }));
+  }, []);
+
+  const updateSessionMessages = useCallback((sessionId: string, messages: ChatMessage[]) => {
+    setSessions(prev => prev.map(session => {
+      if (session.id !== sessionId) return session;
+      return { ...session, updatedAt: Date.now(), messages };
+    }));
+  }, []);
+
+  const setServerConversationId = useCallback((sessionId: string, serverConversationId: string) => {
+    console.log('[SessionStore] setServerConversationId called:', { sessionId, serverConversationId });
+    setSessions(prev => {
+      const updated = prev.map(session => {
+        if (session.id !== sessionId) return session;
+        console.log('[SessionStore] Updating session with serverConversationId:', serverConversationId);
+        return { ...session, serverConversationId };
+      });
+      console.log('[SessionStore] Sessions after update:', updated.map(s => ({ id: s.id, serverConversationId: s.serverConversationId })));
+      return updated;
+    });
+  }, []);
+
+  const deleteSession = useCallback((sessionId: string) => {
+    setSessions(prev => prev.filter(s => s.id !== sessionId));
+    if (currentSessionId === sessionId) {
+      setCurrentSession(null);
+    }
+  }, [currentSessionId, setCurrentSession]);
+
+  const clearAllSessions = useCallback(() => {
+    setSessions([]);
+    setCurrentSession(null);
+  }, [setCurrentSession]);
+
+  const getSessionList = useCallback((): SessionListItem[] => {
+    return sessions
+      .map(sessionToListItem)
+      .sort((a, b) => b.updatedAt - a.updatedAt);
+  }, [sessions]);
+
+  return {
+    sessions,
+    currentSessionId,
+    isLoading,
+    loadSessions,
+    createNewSession,
+    setCurrentSession,
+    getCurrentSession,
+    addMessageToSession,
+    updateSessionMessages,
+    setServerConversationId,
+    deleteSession,
+    clearAllSessions,
+    getSessionList,
+  };
+}
+
+export const SessionContext = createContext<SessionStore | null>(null);
+
+export function useSessionContext(): SessionStore {
+  const ctx = useContext(SessionContext);
+  if (!ctx) throw new Error('SessionContext missing - wrap your app with SessionContext.Provider');
+  return ctx;
+}
+


### PR DESCRIPTION
## Summary
Fixes two issues in the mobile app:
1. Missing back button in Chat and Settings screens
2. Follow-up messages creating new conversations instead of continuing

## Problem 1: No Back Button
The global `headerLeft` override in App.tsx was replacing the back button with just a logo on all screens.

## Solution 1
Only show the logo on the Sessions screen. Chat and Settings screens now show the default back button.

## Problem 2: Conversation Not Continuing
When sending follow-up messages (especially via voice recognition), the app was using stale closure values for `serverConversationId`, causing new conversations to be created.

### Root Cause
Voice recognition callbacks (`rec.onresult`) capture the `send` function at setup time. When that function references `sessionStore.getCurrentSession()`, it uses the OLD `sessionStore` from the captured closure, which has stale state.

## Solution 2
Use **refs** to store latest values that need to be accessible from stale closures:
- `serverConversationIdRef` - Always has the latest server conversation ID
- `sessionIdRef` - Always has the latest session ID
- `sessionStoreRef` - Always has the latest store instance

A `useEffect` keeps these refs updated. In `send()`, we read from refs instead of captured values.

## Testing
1. Navigate to Chat screen - back button should appear (not just logo)
2. Send first message - should create new conversation
3. Send follow-up message - logs should show `Server Conversation ID (from ref): conv_xxx` (not NONE)
4. AI should have context of previous messages

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author